### PR TITLE
Fix leftover mobile hamburger icon

### DIFF
--- a/_sass/_custom.scss
+++ b/_sass/_custom.scss
@@ -166,8 +166,12 @@ a:hover {
 .site-header-inner {
   position: relative;
 }
-/* 隱藏原有的橫向導覽連結（.page-link） */
+/* 隱藏原有的橫向導覽連結與內建漢堡按鈕 */
 .page-link {
+  display: none !important;
+}
+label[for="nav-trigger"],
+.menu-icon {
   display: none !important;
 }
 


### PR DESCRIPTION
## Summary
- hide YAT's default mobile menu icon so only custom hamburger shows

## Testing
- `bundle install`
- `bundle exec jekyll build`


------
https://chatgpt.com/codex/tasks/task_e_6872608d374c832c869a1833405ad2b7